### PR TITLE
Fix ambiguous column references in spatial queries

### DIFF
--- a/Sources/FluentPostGIS/Queries/QueryBuilder+Helpers.swift
+++ b/Sources/FluentPostGIS/Queries/QueryBuilder+Helpers.swift
@@ -15,8 +15,9 @@ extension QueryBuilder {
     static func path<M, F>(_ field: KeyPath<M, F>) -> any SQLExpression
         where M: Schema, F: QueryableProperty, F.Model == M
     {
-        let path = M.path(for: field).map(\.description).joined(separator: "_")
-        return SQLColumn(path)
+        let schema = SQLIdentifier(M.schemaOrAlias)
+        let path = SQLIdentifier(M.path(for: field).map(\.description).joined(separator: "_"))
+        return SQLColumn(path, table: schema)
     }
 }
 

--- a/Tests/FluentPostGISTests/FluentPostGISTestCase.swift
+++ b/Tests/FluentPostGISTests/FluentPostGISTestCase.swift
@@ -1,5 +1,6 @@
 import FluentKit
 import FluentPostgresDriver
+import FluentPostGIS
 import PostgresKit
 import XCTest
 
@@ -11,7 +12,7 @@ class FluentPostGISTestCase: XCTestCase {
             on: self.dbs.eventLoopGroup.next()
         )!
     }
-
+  
     override func setUp() async throws {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let threadPool = NIOThreadPool(numberOfThreads: 1)
@@ -25,6 +26,7 @@ class FluentPostGISTestCase: XCTestCase {
         )
         self.dbs.use(.postgres(configuration: configuration), as: .psql)
 
+        try await EnablePostGISMigration().prepare(on: self.db)
         for migration in self.migrations {
             try await migration.prepare(on: self.db)
         }
@@ -34,6 +36,7 @@ class FluentPostGISTestCase: XCTestCase {
         for migration in self.migrations {
             try await migration.revert(on: self.db)
         }
+        try await EnablePostGISMigration().revert(on: self.db)
     }
 
     private let migrations: [any AsyncMigration] = [
@@ -42,5 +45,6 @@ class FluentPostGISTestCase: XCTestCase {
         UserPathMigration(),
         UserAreaMigration(),
         UserCollectionMigration(),
+        GuestMigration()
     ]
 }

--- a/Tests/FluentPostGISTests/QueryTests.swift
+++ b/Tests/FluentPostGISTests/QueryTests.swift
@@ -1,7 +1,24 @@
 @testable import FluentPostGIS
+import FluentKit
 import XCTest
 
 final class QueryTests: FluentPostGISTestCase {
+    func testAlias() {
+        let query = Guest.query(on: self.db)
+            .join(Host.self, on: \Guest.$host.$id == \Host.$id)
+        
+        for join in query.query.joins {
+            if case DatabaseQuery.Join.join(
+                schema: let schema,
+                alias: let alias?,
+                let method,
+                let foreign,
+                let local
+            ) = join
+            { XCTAssertTrue(!alias.isEmpty) }
+        }
+    }
+    
     func testContains() async throws {
         let exteriorRing = GeometricLineString2D(points: [
             GeometricPoint2D(x: 0, y: 0),

--- a/Tests/FluentPostGISTests/TestModels.swift
+++ b/Tests/FluentPostGISTests/TestModels.swift
@@ -1,6 +1,42 @@
 import FluentKit
 import FluentPostGIS
 
+
+
+final class Host: ModelAlias {
+    static let name = "host"
+    let model = Guest()
+}
+
+final class Guest: Model, @unchecked Sendable {
+    static let schema: String = "guest"
+    
+    @ID(custom: .id, generatedBy: .database)
+    var id: Int?
+    
+    @OptionalParent(key: "host_id")
+    var host: Guest?
+    
+    init() {}
+    
+    init(hostID: Guest.IDValue? = nil) {
+        self.$host.id = hostID
+    }
+}
+
+struct GuestMigration: AsyncMigration {
+    func prepare(on database: any Database) async throws {
+        try await database.schema(Guest.schema)
+            .field(.id, .int, .identifier(auto: true))
+            .field("host_id", .int, .references(Guest.schema, "id"))
+            .create()
+    }
+    
+    func revert(on database: any Database) async throws {
+        try await database.schema(Guest.schema).delete()
+    }
+}
+
 final class UserLocation: Model, @unchecked Sendable {
     static let schema = "user_location"
 


### PR DESCRIPTION
Resolves an issue where column references were becoming ambiguous in complex joins involving geometry columns. This change modifies the path generation to explicitly qualify columns with their schema or table alias, replacing the previous approach that created unqualified column names. Specifically, we now prepend the schema or alias name with a dot separator before the column path, ensuring proper SQL column qualification.

This prevents errors like "column reference is ambiguous" when using spatial functions on tables with similar column names in multi-table joins.