### PR TITLE
Add PostGIS extension migration and configuration

### DIFF
--- a/Tests/FluentPostGISTests/FluentPostGISTestCase.swift
+++ b/Tests/FluentPostGISTests/FluentPostGISTestCase.swift
@@ -37,10 +37,11 @@ class FluentPostGISTestCase: XCTestCase {
     }
 
     private let migrations: [any AsyncMigration] = [
+        EnablePostGISMigration(),
         UserLocationMigration(),
         CityMigration(),
         UserPathMigration(),
         UserAreaMigration(),
-        UserCollectionMigration(),
+        UserCollectionMigration()
     ]
 }

--- a/Tests/FluentPostGISTests/FluentPostGISTestCase.swift
+++ b/Tests/FluentPostGISTests/FluentPostGISTestCase.swift
@@ -1,4 +1,5 @@
 import FluentKit
+import FluentPostGIS
 import FluentPostgresDriver
 import PostgresKit
 import XCTest

--- a/Tests/FluentPostGISTests/TestModels.swift
+++ b/Tests/FluentPostGISTests/TestModels.swift
@@ -148,26 +148,3 @@ struct UserCollectionMigration: AsyncMigration {
     }
 }
 
-public struct EnablePostGISMigration: AsyncMigration, Sendable {
-    public init() {}
-
-    public enum EnablePostGISMigrationError: Error, Sendable {
-        case notSqlDatabase
-    }
-
-    public func prepare(on database: any Database) async throws {
-        guard let db = database as? any SQLDatabase else {
-            throw EnablePostGISMigrationError.notSqlDatabase
-        }
-        try await db.raw("CREATE EXTENSION IF NOT EXISTS \"postgis\"").run()
-    }
-
-    public func revert(on database: any Database) async throws {
-        guard let db = database as? any SQLDatabase else {
-            throw EnablePostGISMigrationError.notSqlDatabase
-        }
-        try await db.raw("DROP EXTENSION IF EXISTS \"postgis\"").run()
-    }
-}
-
-public let FluentPostGISSrid: UInt = 4326

--- a/Tests/FluentPostGISTests/TestModels.swift
+++ b/Tests/FluentPostGISTests/TestModels.swift
@@ -1,3 +1,4 @@
+import SQLKit
 import FluentKit
 import FluentPostGIS
 
@@ -146,3 +147,27 @@ struct UserCollectionMigration: AsyncMigration {
         try await database.schema(UserCollection.schema).delete()
     }
 }
+
+public struct EnablePostGISMigration: AsyncMigration, Sendable {
+    public init() {}
+
+    public enum EnablePostGISMigrationError: Error, Sendable {
+        case notSqlDatabase
+    }
+
+    public func prepare(on database: any Database) async throws {
+        guard let db = database as? any SQLDatabase else {
+            throw EnablePostGISMigrationError.notSqlDatabase
+        }
+        try await db.raw("CREATE EXTENSION IF NOT EXISTS \"postgis\"").run()
+    }
+
+    public func revert(on database: any Database) async throws {
+        guard let db = database as? any SQLDatabase else {
+            throw EnablePostGISMigrationError.notSqlDatabase
+        }
+        try await db.raw("DROP EXTENSION IF EXISTS \"postgis\"").run()
+    }
+}
+
+public let FluentPostGISSrid: UInt = 4326


### PR DESCRIPTION
- Add EnablePostGISMigration to automatically create/drop PostGIS extension
- Include EnablePostGISMigration as first migration in test suite
- Add SQLKit import for raw SQL execution
- Define FluentPostGISSrid constant (4326) for spatial reference
- Fix trailing comma in migrations array